### PR TITLE
Ignore stroke-opacity

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,20 +7,21 @@ module.exports = postcss.plugin('postcss-default-unit', function (opts) {
     opts = opts || {};
     opts.unit = opts.unit || 'px';
     opts.ignore = extend({
-        'columns':      true,
-        'column-count': true,
-        'fill-opacity': true,
-        'font-weight':  true,
-        'line-height':  true,
-        'opacity':      true,
-        'orphans':      true,
-        'widows':       true,
-        'z-index':      true,
-        'zoom':         true,
-        'flex':         true,
-        'order':        true,
-        'flex-grow':    true,
-        'flex-shrink':  true
+        'columns':          true,
+        'column-count':     true,
+        'fill-opacity':     true,
+        'stroke-opacity':   true,
+        'font-weight':      true,
+        'line-height':      true,
+        'opacity':          true,
+        'orphans':          true,
+        'widows':           true,
+        'z-index':          true,
+        'zoom':             true,
+        'flex':             true,
+        'order':            true,
+        'flex-grow':        true,
+        'flex-shrink':      true
     }, opts.ignore);
 
     function replacer(match) {


### PR DESCRIPTION
Since `stroke-opacity` is a unitless value, let's include it in the list of ignored properties.