### PR TITLE
`grid-area` ignored by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = postcss.plugin('postcss-default-unit', function (opts) {
         'flex':         true,
         'order':        true,
         'flex-grow':    true,
-        'flex-shrink':  true
+        'flex-shrink':  true,
+        'grid-area':    true  
     }, opts.ignore);
 
     function replacer(match) {


### PR DESCRIPTION
The `grid-area` property

https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area

was transformed to get px values

```css
// input
.myClass {
  grid-area: 1 / 1 / 2 / 4;
}

// output
.myClass {
  grid-area: 1px / 1px / 2px / 4px;
}
```

but it shouldn't.

So this PR adds `"grid-area"` to the properties being ignored by default